### PR TITLE
Update HTTPMethods enum

### DIFF
--- a/swiftui-starter/swiftui-starter/Src/Utilities/HTTPClient.swift
+++ b/swiftui-starter/swiftui-starter/Src/Utilities/HTTPClient.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 enum HTTPMethods: String {
-    case DELETE = "DELETE"
-    case GET = "GET"
-    case PATCH = "PATCH"
-    case POST = "POST"
-    case PUT = "PUT"
+    case DELETE
+    case GET
+    case PATCH
+    case POST
+    case PUT
 }
 
 class HTTPClient {


### PR DESCRIPTION
Update the HTTPMethods enum in the HTTPClient, as the rawValue can be accessed without writing out the strings.
