### PR TITLE
Update with Swift Concurrency, NavigationStack, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# swiftui-starter
-Starter/reference code for a simple SwiftUI app.
+# SwiftUI Starter App
+Starter codebase for a simple SwiftUI app, using modern Swift concurrency (async/await), NavigationStack, and MVVM architecture with proper error handling. 

--- a/swiftui-starter/swiftui-starter/Src/Utilities/DataStore.swift
+++ b/swiftui-starter/swiftui-starter/Src/Utilities/DataStore.swift
@@ -9,16 +9,12 @@ import Foundation
 
 class DataStore {
 
-    // MARK: - Class Methods
+    // MARK: - Methods
     
     // Retrieve all of a particular type of item using a GET request.
-    static func getItems(completionHandler: @escaping ([Item]?) -> Void) {
+    static func getItems() async throws -> [Item] {
         let url = Constants.API.baseURL + Constants.API.path
-
-        HTTPClient.get(url: url) { items in
-            completionHandler(items)
-            return
-        }
+        return try await HTTPClient.get<[Item]>(url: url)
     }
     
 }

--- a/swiftui-starter/swiftui-starter/Src/Utilities/HTTPClient.swift
+++ b/swiftui-starter/swiftui-starter/Src/Utilities/HTTPClient.swift
@@ -15,6 +15,13 @@ enum HTTPMethods: String {
     case PUT
 }
 
+enum HTTPClientError: Error {
+    case invalidURL
+    case invalidResponse
+    case decodingError(Error)
+    case networkError(Error)
+}
+
 class HTTPClient {
     
     // MARK: - Class Methods
@@ -23,31 +30,37 @@ class HTTPClient {
     // Assumes:
     // 1) The response uses snake_case.
     // 2) Authorization is provided via an API key from Constants.
-    static func get<T: Decodable>(url: String, completionHandler: @escaping (T?) -> Void) {
-        guard let url = URL(string: url) else { return }
+    static func get<T: Decodable>(url: String) async throws -> T {
+        guard let url = URL(string: url) else {
+            throw HTTPClientError.invalidURL
+        }
         
         var request = URLRequest(url: url)
         request.httpMethod = HTTPMethods.GET.rawValue
         request.setValue(Constants.API.apiKey, forHTTPHeaderField: "Authorization")
             
-        let sharedSession = URLSession.shared
-        
-        let dataTask = sharedSession.dataTask(with: request) {
-            (data, response, error) in
-                do {
-                    if let jsonData = data {
-                        let decoder = JSONDecoder()
-                        decoder.keyDecodingStrategy = .convertFromSnakeCase
-                        let typedObject: T? = try decoder.decode(T.self, from: jsonData)
-                        completionHandler(typedObject)
-                    }
-                }
-                catch {
-                    print(error)
-                }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                throw HTTPClientError.invalidResponse
+            }
+            
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            
+            do {
+                let typedObject = try decoder.decode(T.self, from: data)
+                return typedObject
+            } catch {
+                throw HTTPClientError.decodingError(error)
+            }
+        } catch let error as HTTPClientError {
+            throw error
+        } catch {
+            throw HTTPClientError.networkError(error)
         }
-        
-        dataTask.resume()
     }
 }
 

--- a/swiftui-starter/swiftui-starter/Src/ViewModels/ItemsList.swift
+++ b/swiftui-starter/swiftui-starter/Src/ViewModels/ItemsList.swift
@@ -7,30 +7,31 @@
 
 import Foundation
 
+@MainActor
 class ItemsList: ObservableObject {
 
     // MARK: - Public Variables
     
     @Published var items = [Item]()
-    @Published var error = false
+    @Published var error: Error?
     
     // MARK: Init(s)
     
     init() {
-        getItems()
+        Task {
+            await getItems()
+        }
     }
     
     // MARK: - Public Functions
     
-    func getItems() {
-        DataStore.getItems { items in
-            guard let items = items else {
-                self.error = true
-                return
-            }
-            DispatchQueue.main.async {
-                self.items = items
-            }
+    func getItems() async {
+        do {
+            let fetchedItems = try await DataStore.getItems()
+            self.items = fetchedItems
+            self.error = nil
+        } catch {
+            self.error = error
         }
     }
 

--- a/swiftui-starter/swiftui-starter/Src/Views/ListView.swift
+++ b/swiftui-starter/swiftui-starter/Src/Views/ListView.swift
@@ -15,7 +15,7 @@ struct ListView: View {
 
     // MARK: - Body
     var body: some View {
-        NavigationView {
+        NavigationStack {
             // UNCOMMENT and replace the working List when an API endpoint is added.
             // List(itemsList.items, id: \.id) { item in
             //     NavigationLink(destination: DetailView(item: item)) {
@@ -36,7 +36,7 @@ struct ListView: View {
             }
             // END code to replace
             .listStyle(PlainListStyle())
-        .navigationBarTitle("SwiftUI Starter", displayMode: .large)
+        .navigationTitle("SwiftUI Starter")
         }
     }
     

--- a/swiftui-starter/swiftui-starter/Src/swiftui_starterApp.swift
+++ b/swiftui-starter/swiftui-starter/Src/swiftui_starterApp.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @main
 struct swiftui_starterApp: App {
-    private let itemsList = ItemsList()
+    @StateObject private var itemsList = ItemsList()
     
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
# Changes
- **Replace `NavigationView` with `NavigationStack`** - NavigationView is deprecated in iOS 16+. Use NavigationStack with the modern navigation API.
- **Convert to async/await** - Replace completion handlers in HTTPClient and DataStore with Swift concurrency (async/await). URLSession provides async methods.
- **Use `@StateObject` instead of `@ObservedObject`** - For the root view model in the app file, use `@StateObject` to properly manage ownership.
- **Modernize concurrency with @MainActor** - Replace `DispatchQueue.main.async` with `@MainActor` annotations for cleaner, safer main-thread updates.
- **Better error handling** - Add proper error types and use Result or throwing async functions instead of optional returns and boolean error flags.
- **Update the README** a bit.